### PR TITLE
Batch send

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org' do
   gem 'aws-sdk', '~> 2'
+  gem 'logstash-mixin-aws', :git => "https://github.com/envato/logstash-mixin-aws", :branch => "assume-role"
 end
 gemspec

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -177,6 +177,7 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
       rounds.times do
         @event_buffer_lock.synchronize do
           events = @event_buffer.slice!(0, 500)
+          break if events.nil?
           aws_firehose_client.put_record_batch({
             delivery_stream_name: @stream,
             records: events.map { |e| {data: e} }
@@ -189,7 +190,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
       raise LogStash::Error, "Firehose: AWS resource not found error: #{error}"
     rescue Exception => error
       @logger.error "Firehose: AWS delivery error", :error => error
-      @logger.info "Failed to deliver event: #{encoded_event}"
     end
   end
 

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -67,12 +67,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
   # Register plugin
   public
   def register
-    # require "aws-sdk"
-    # required if using ruby version < 2.0
-    # http://ruby.awsblog.com/post/Tx16QY1CI5GVBFT/Threading-with-the-AWS-SDK-for-Ruby
-    #Aws.eager_autoload!(Aws::Firehose)
-    #Aws.eager_autoload!(services: %w(Firehose))
-
     # Validate stream name
     if @stream.nil? || @stream.empty?
       @logger.error("Firehose: stream name is empty", :stream => @stream)

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -188,7 +188,7 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
       # Firehose stream not found
       @logger.error "Firehose: AWS resource error", :error => error
       raise LogStash::Error, "Firehose: AWS resource not found error: #{error}"
-    rescue Exception => error
+    rescue Aws::Firehose::Errors::ServiceError => error
       @logger.error "Firehose: AWS delivery error", :error => error
     end
   end

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -45,8 +45,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
 
   # make properties visible for tests
   attr_accessor :stream
-  attr_accessor :access_key_id
-  attr_accessor :secret_access_key
   attr_accessor :codec
 
   config_name "firehose"
@@ -57,8 +55,6 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
   # Firehose stream info
   config :region, :validate => :string, :default => "us-east-1"
   config :stream, :validate => :string
-  config :access_key_id, :validate => :string
-  config :secret_access_key, :validate => :string
 
   #
   # Register plugin

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -173,7 +173,7 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
       @event_buffer.each_slice(500) do |events|
         aws_firehose_client.put_record_batch({
           delivery_stream_name: @stream,
-          record: events.map { |e| {data: e} }
+          records: events.map { |e| {data: e} }
         })
         # This will result in duplicate results if some failed to send
         @event_buffer.slice(500)

--- a/lib/logstash/outputs/firehose.rb
+++ b/lib/logstash/outputs/firehose.rb
@@ -164,7 +164,7 @@ class LogStash::Outputs::Firehose < LogStash::Outputs::Base
       # Firehose stream not found
       @logger.error "Firehose: AWS resource error", :error => error
       raise LogStash::Error, "Firehose: AWS resource not found error: #{error}"
-    rescue Exception => error
+    rescue Aws::Firehose::Errors::ServiceError => error
       # TODO Retry policy
       # TODO Fallback policy
       # TODO Keep failed events somewhere, probably in fallback file

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "stud", "~> 0.0.22"
   s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
-  s.add_runtime_dependency "logstash-mixin-aws", ">= 2.0.2"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "logstash-codec-json_lines"
   s.add_development_dependency "logstash-devutils"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-firehose'
-  s.version       = "0.0.5"
+  s.version       = "0.0.6"
   s.licenses      = ["Apache License (2.0)"]
   s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
   s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-firehose'
-  s.version       = "0.0.4"
+  s.version       = "0.0.5"
   s.licenses      = ["Apache License (2.0)"]
   s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
   s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-firehose'
-  s.version       = "0.0.3"
+  s.version       = "0.0.4"
   s.licenses      = ["Apache License (2.0)"]
   s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
   s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,12 +1,12 @@
 Gem::Specification.new do |s|
-  s.name = 'logstash-output-firehose'
-  s.version         = "0.0.2"
-  s.licenses = ["Apache License (2.0)"]
-  s.summary = "Output plugin to push data into AWS Kinesis Firehose stream."
-  s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
-  s.authors = ["Valera Chevtaev"]
-  s.email = "myltik@gmail.com"
-  s.homepage = "https://github.com/chupakabr/logstash-output-firehose"
+  s.name          = 'logstash-output-firehose'
+  s.version       = "0.0.2"
+  s.licenses      = ["Apache License (2.0)"]
+  s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
+  s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
+  s.authors       = ["Valera Chevtaev"]
+  s.email         = "myltik@gmail.com"
+  s.homepage      = "https://github.com/chupakabr/logstash-output-firehose"
   s.require_paths = ["lib"]
 
   # Files

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "stud", "~> 0.0.22"
-  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "logstash-codec-json_lines"
   s.add_development_dependency "logstash-devutils"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-firehose'
-  s.version       = "0.0.2"
+  s.version       = "0.0.3"
   s.licenses      = ["Apache License (2.0)"]
   s.summary       = "Output plugin to push data into AWS Kinesis Firehose stream."
   s.description   = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-firehose.gemspec
+++ b/logstash-output-firehose.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-codec-line"
   s.add_runtime_dependency "logstash-codec-json_lines"
   s.add_development_dependency "logstash-devutils"
+  s.add_development_dependency "timecop"
 end

--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -47,7 +47,7 @@ describe LogStash::Outputs::Firehose do
     it "returns same string" do
       expect(firehose_double).to receive(:put_record_batch).with({
         delivery_stream_name: stream_name,
-        record: [
+        records: [
           {
             data: expected_event
           },

--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -1,39 +1,67 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/firehose"
-require "logstash/codecs/plain"
 require "logstash/codecs/line"
 require "logstash/codecs/json_lines"
 require "logstash/event"
 require "aws-sdk"
+require "timecop"
 
 describe LogStash::Outputs::Firehose do
   dataStr = "123,someValue,1234567890"
 
   let(:sample_event) { LogStash::Event.new("message" => dataStr) }
-  let(:expected_event) { LogStash::Event.new("message" => dataStr) }
-  let(:output) { LogStash::Outputs::Firehose.new({"codec" => "plain"}) }
+  let(:time_now) { Time.now }
+  let(:expected_event) { "#{time_now.strftime("%FT%H:%M:%S.%3NZ")} %{host} 123,someValue,1234567890" }
+  let(:firehose_double) { instance_double(Aws::Firehose::Client) }
+  let(:stream_name) { "aws-test-stream" }
+  subject { LogStash::Outputs::Firehose.new({"codec" => "plain"}) }
 
   before do
     Thread.abort_on_exception = true
 
     # Setup Firehose client
-    output.stream = "aws-test-stream"
-    output.register
+    subject.stream = stream_name
+    subject.register
+
+    allow(Aws::Firehose::Client).to receive(:new).and_return(firehose_double)
+    allow(firehose_double).to receive(:put_record)
+    allow(firehose_double).to receive(:put_record_batch)
   end
 
-  describe "receive message with plain codec" do
-    subject {
-      expect(output).to receive(:handle_event) do |arg|
-        arg
-      end
-      output.receive(sample_event)
-    }
-
+  describe "receive one message" do
     it "returns same string" do
-      expect(subject).not_to eq(nil)
-      expect(subject.include? expected_event["message"]).to be_truthy
-      # expect(subject).to eq(expected_event["message"])
+      expect(firehose_double).to receive(:put_record).with({
+        delivery_stream_name: stream_name,
+        record: {
+            data: expected_event
+        }
+      })
+      Timecop.freeze(time_now) do
+        subject.receive(sample_event)
+      end
+    end
+  end
+
+  describe "receive multiple messages" do
+    it "returns same string" do
+      expect(firehose_double).to receive(:put_record_batch).with({
+        delivery_stream_name: stream_name,
+        record: [
+          {
+            data: expected_event
+          },
+          {
+            data: expected_event
+          },
+          {
+            data: expected_event
+          },
+        ]
+      })
+      Timecop.freeze(time_now) do
+        subject.multi_receive([sample_event, sample_event, sample_event])
+      end
     end
   end
 end

--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -97,5 +97,11 @@ describe LogStash::Outputs::Firehose do
         subject.multi_receive([])
       end
     end
+
+    it "doesn't crash if no events are sent" do
+      Thread.new { subject.multi_receive(Array.new(499, sample_event_1)) }
+      Thread.new { subject.multi_receive([sample_event_1, sample_event_2]) }
+      expect { subject.multi_receive([sample_event_1, sample_event_2]) }.not_to raise_exception
+    end
   end
 end

--- a/spec/outputs/firehose_spec.rb
+++ b/spec/outputs/firehose_spec.rb
@@ -19,8 +19,6 @@ describe LogStash::Outputs::Firehose do
 
     # Setup Firehose client
     output.stream = "aws-test-stream"
-    output.access_key_id = "Key ID"
-    output.secret_access_key = "Secret key"
     output.register
   end
 


### PR DESCRIPTION
## Context

We're migrating Heroku Logs from Lambda to EC2. This requires we receive logs from Heroku using syslog and forward them to Kinesis and Firehose. Since Firehose is in a seperate AWS Account, we need to assume a role to access it.

During initial implementation we noticed significant performance issues. Because this plugin is single threaded and it's sending each log message to firehose one at a time (which takes somewhere in the range of 100ms), this was exorbitantly slow. Due to the blocking nature of Logstash ingestion pipelines this caused back pressure which ultimately resulted in us dropping connections to Heroku.

## Changes

Allow the aws client to assume a role by removing the access_key_id and secrey_key parameters. These are inherited from logstash-mixin-aws anyway and need to be optional.

Update this plugin to support Logstash 5.x

Send data in batches of 500 records at a time, to speed up throughput of the single thread.

## Considerations

Possible future speed improvements:
- Make it multi-threaded. Given the use of a Mutex this is probably OK but would require further thought and testing. Given the use of the Mutex though the possibility of lock contention is high.